### PR TITLE
Update ecommerce-product-catalog.php

### DIFF
--- a/ecommerce-product-catalog.php
+++ b/ecommerce-product-catalog.php
@@ -38,7 +38,7 @@ register_activation_hook( __FILE__, 'add_product_caps' );
 register_activation_hook( __FILE__, 'create_products_page' );
 
 function implecode_register_styles() {
- wp_register_style( 'al_product_styles', '/wp-content/plugins/' . dirname( plugin_basename( __FILE__ ) ) . '/css/al_product.css' );
+ wp_register_style( 'al_product_styles',  plugins_url(). "/" . dirname( plugin_basename( __FILE__ ) ) . '/css/al_product.css' );
  wp_enqueue_style( 'al_product_styles' ); 
 }
 


### PR DESCRIPTION
 Product catalog plugin is currently hard coding the plugins directory path.

Hard coding the plugins directory path only works for standard WP implementations. If wp-content is not in the same directory as the standard WP code then the plugin does not work anymore. 
WP codex (http://codex.wordpress.org/Function_Reference/wp_register_style) suggest "You should never hardcode URLs to local styles..."
Issue reference #1
The fix is using the plugins_url() function to get the correct directory name instead of /wp-content/plugins/.
Please update
